### PR TITLE
Avoid switching directories

### DIFF
--- a/bin/johnny_deps
+++ b/bin/johnny_deps
@@ -12,7 +12,7 @@ set -e
 while read package version; do
   go get -v -u -d $package/...
   echo "Setting $package to version $version"
-  cd $GOPATH/src/$package && git checkout $version
+  GIT_DIR="$GOPATH/src/$package/.git" git checkout $version
   echo "Installing $package"
   go install $package/...
 done < Godeps


### PR DESCRIPTION
There's no need to change directories. Git can run from anywhere :)

This also is less prone to errors / problems when you have a CDPATH set (alternatively, you'd want to `unset CDPATH` at the start of the script to avoid weird things going on, or having all the paths printed to the console when running the script).
