### PR TITLE
Quote all strings to allow for whitespace.

### DIFF
--- a/bin/johnny_deps
+++ b/bin/johnny_deps
@@ -10,9 +10,9 @@ set -e
 ## in the project.
 
 while read package version; do
-  go get -v -u -d $package/...
+  go get -v -u -d "$package/..."
   echo "Setting $package to version $version"
-  cd $GOPATH/src/$package && git checkout $version
+  cd "$GOPATH/src/$package" && git checkout "$version"
   echo "Installing $package"
-  go install $package/...
+  go install "$package/..."
 done < ${1-"Godeps"}


### PR DESCRIPTION
This is not strictly necessary for all of the strings, but it is generally a
good practice in Bash. In particular, $GOPATH could contain spaces.
