### PR TITLE
Use git fetch instead of git pull; avoids pull-specific behaviors

### DIFF
--- a/bin/johnny_deps
+++ b/bin/johnny_deps
@@ -61,7 +61,7 @@ sed 's/#.*//;/^\s*$/d' "$depfile" \
 	# branch instead.
 	echo ">> [johnny-deps] setting $package to version $sha"
 	if ! git checkout -q "$sha"; then
-		git pull -q
+		git fetch -q
 		git checkout -q "$sha"
 	fi
 	git branch --contains "${sha}" | grep -v -e 'no branch' -e 'detached from' \


### PR DESCRIPTION
Using `git pull` can cause problems when someone has, for example, specified to do a rebase with all pulls. Or when the repo isn't on any branch.
