### PR TITLE
Fix formatting for return codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,12 +224,12 @@ the update multiple times before you're done.
 
 These are the return codes for `jd`:
 
-0. Success
-1. Error with parameters
-2. Bad dependencies or unable to read them
-3. Version mismatch detected
-4. External command failed
-5. Unable to checkout requested revision
+* 0 - Success
+* 1 - Error with parameters
+* 2 - Bad dependencies or unable to read them
+* 3 - Version mismatch detected
+* 4 - External command failed
+* 5 - Unable to checkout requested revision
 
 ## Workflows
 


### PR DESCRIPTION
The return codes section was badly rendered by Github after reading it as a Markdown numbered list.
