### PR TITLE
Include test files in dependency analysis

### DIFF
--- a/bin/jd
+++ b/bin/jd
@@ -237,7 +237,8 @@ sub get_compiler_deps
 	my $oldcwd = cwd();
 	chdir $projroot;
 
-	my $template = '{{join .Imports "\n"}}';
+	my $template = '{{join .Imports "\n"}}{{"\n"}}' .
+		'{{join .TestImports "\n"}}{{"\n"}}{{join .XTestImports "\n"}}';
 	my @deps = grep m!^github\.com/!,
 		run_or_die("$go list -f '$template' ./... | sort -u");
 	my %projects;
@@ -464,7 +465,7 @@ Project:
   Specified just like in the dependencies file (Godeps). If no project
   is provided, jd searches for a project in the current directory.
 
-Options for build:
+Options for build/install:
   -d         Use -d when running get.
   -r <rev>   Use -r <rev> when running get.
 


### PR DESCRIPTION
Test files are now checked for dependencies, just like the main package
sources are. Any extra dependency will be included in the Godeps file
and will be required for building. Projects with tests in such
conditions will need to have their Godeps regenerated.

Closes #65.
